### PR TITLE
fixed a bug how changed file is deleted

### DIFF
--- a/tests/utils/functools/test_cache.py
+++ b/tests/utils/functools/test_cache.py
@@ -176,6 +176,12 @@ class TestCacheDescriptor(object):
 
         assert self.instance.foo == 'bar'
 
+    def test_set_read_only(self):
+        self.descriptor.as_property = True
+
+        with pytest.raises(AttributeError):
+            self.instance.foo = 'foo'
+
     def test_delete_property_not_present(self):
         self.descriptor.as_property = True
 


### PR DESCRIPTION
Previously file was never actually removed since file.storage
was always empty due to a fact how Django pickles FileField.
Normally FileFieldDescriptor would populate the necessary
attributes back however since in order to detect which fields
change during save, they need to be copied which means that
storage attribute is lost and so the file was not actually
removed. In this fix we explicitly copy the necessary parameters
to the old file field so that it can successfully be removed
by the appropriate storage mechanism.
